### PR TITLE
Added config specification for API calls and API help

### DIFF
--- a/data/api/config.py
+++ b/data/api/config.py
@@ -1,0 +1,44 @@
+from collections import OrderedDict
+
+import app.courses
+import app.ping
+import app.courses_v2
+import app.housing
+
+config = OrderedDict([
+    (r'/ping$', {
+        'handler': app.ping.PingHandler,
+        'config': app.ping.PingHandler.config
+        }),
+    (r'/courses$', {
+        'handler': app.courses.CoursesHandler,
+        'config': app.courses.CoursesHandler.config
+        }),
+    (r'/courses/v2/courses$', {
+        'handler': app.courses_v2.CoursesV2Handler,
+        'config': app.courses_v2.CoursesV2Handler.config
+        }),
+    (r'/courses/v2/sections$', {
+        'handler': app.courses_v2.SectionsV2Handler,
+        'config': app.courses_v2.CoursesV2Handler.config
+        }),
+    (r'/courses/v2/search$', {
+        'handler': app.courses_v2.FullTextSearchHandler,
+        'config': app.courses_v2.FullTextSearchHandler.config
+        }),
+    (r'/housing/rooms$', {
+        'handler': app.housing.RoomHandler,
+        'config': app.housing.RoomHandler.config
+        }),
+    (r'/housing/buildings$', {
+        'handler': app.housing.BuildingHandler,
+        'config': app.housing.BuildingHandler.config
+        }),
+])
+
+def api_handlers():
+    handlers = []
+    for endpoint, apiconf in config.iteritems():
+        handlers.append((endpoint, apiconf['handler']))
+    return handlers
+

--- a/data/app/courses.py
+++ b/data/app/courses.py
@@ -10,16 +10,43 @@ import models.courses.courses_functions as model_functions
 class CoursesHandler(basic.BaseHandler):
     pgquery = lib.pg.PGQuery(model, model_functions)
 
+    config = {
+        'GET': {
+            'params': basic.pg_function_params(model_functions, {
+                'limit': {
+                    'type': 'int',
+                    'default': None
+                },
+                'page': {
+                    'type': 'int',
+                    'default': 0
+                },
+                'pretty': {
+                    'type': 'bool',
+                    'default': None
+                },
+                'jsonp': {
+                    'type': 'bool',
+                    'default': None
+                },
+            }),
+            'function': 'process_get'
+        }
+    }
+
     @tornado.web.asynchronous
     @basic.format_api_errors
     @app.basic.validate_token
-    def get(self):
+    def process_get(self, params):
         recognized_arguments = self.valid_query_arguments(model_functions)
-        queries = self.get_recognized_arguments(recognized_arguments)
-        limit = self.get_int_argument("limit", None)
-        page = self.get_int_argument("page", 0)
-        pretty = self.get_bool_argument("pretty", None)
-        jsonp = self.get_argument("jsonp", None)
+
+        limit = params['limit']
+        page = params['page']
+        pretty = params['pretty']
+        jsonp = params['jsonp']
+
+        queries = {query: params[query] for query in recognized_arguments if params[query]}
+
         if not queries:
             return self.error(status_code=400, status_txt="MISSING_QUERY_ARGUMENTS")
         internal_callback = functools.partial(self._finish, pretty=pretty, jsonp=jsonp)

--- a/data/app/housing.py
+++ b/data/app/housing.py
@@ -11,16 +11,43 @@ from models.housing import building_functions
 class RoomHandler(app.basic.BaseHandler):
     pgquery = lib.pg.PGQuery(room, room_functions)
 
+    config = {
+        'GET': {
+            'params': app.basic.pg_function_params(room_functions, {
+                'limit': {
+                    'type': 'int',
+                    'default': None
+                },
+                'page': {
+                    'type': 'int',
+                    'default': 0
+                },
+                'pretty': {
+                    'type': 'bool',
+                    'default': None
+                },
+                'jsonp': {
+                    'type': 'bool',
+                    'default': None
+                },
+            }),
+            'function': 'process_get'
+        }
+    }
+
     @tornado.web.asynchronous
     @app.basic.format_api_errors
     @app.basic.validate_token
-    def get(self):
+    def process_get(self, params):
         recognized_arguments = self.valid_query_arguments(room_functions)
-        queries = self.get_recognized_arguments(recognized_arguments)
-        limit = self.get_int_argument("limit", None)
-        page = self.get_int_argument("page", 0)
-        pretty = self.get_bool_argument("pretty", None)
-        jsonp = self.get_argument("jsonp", None)
+
+        limit = params['limit']
+        page = params['page']
+        pretty = params['pretty']
+        jsonp = params['jsonp']
+
+        queries = {query: params[query] for query in recognized_arguments if params[query]}
+
         if not queries:
             return self.error(status_code=400, status_txt="MISSING_QUERY_ARGUMENTS")
         internal_callback = functools.partial(self._finish, pretty=pretty, jsonp=jsonp)
@@ -35,16 +62,43 @@ class RoomHandler(app.basic.BaseHandler):
 class BuildingHandler(app.basic.BaseHandler):
     pgquery = lib.pg.PGQuery(building, building_functions)
 
+    config = {
+        'GET': {
+            'params': app.basic.pg_function_params(building_functions, {
+                'limit': {
+                    'type': 'int',
+                    'default': None
+                },
+                'page': {
+                    'type': 'int',
+                    'default': 0
+                },
+                'pretty': {
+                    'type': 'bool',
+                    'default': None
+                },
+                'jsonp': {
+                    'type': 'bool',
+                    'default': None
+                },
+            }),
+            'function': 'process_get'
+        }
+    }
+
     @tornado.web.asynchronous
     @app.basic.format_api_errors
     @app.basic.validate_token
-    def get(self):
+    def process_get(self, params):
         recognized_arguments = self.valid_query_arguments(building_functions)
-        queries = self.get_recognized_arguments(recognized_arguments)
-        limit = self.get_int_argument("limit", None)
-        page = self.get_int_argument("page", 0)
-        pretty = self.get_bool_argument("pretty", None)
-        jsonp = self.get_argument("jsonp", None)
+
+        limit = params['limit']
+        page = params['page']
+        pretty = params['pretty']
+        jsonp = params['jsonp']
+
+        queries = {query: params[query] for query in recognized_arguments if params[query]}
+
         if not queries:
             return self.error(status_code=400, status_txt="MISSING_QUERY_ARGUMENTS")
         internal_callback = functools.partial(self._finish, pretty=pretty, jsonp=jsonp)

--- a/data/app/ping.py
+++ b/data/app/ping.py
@@ -1,0 +1,31 @@
+from app import basic
+import app
+import functools
+
+import json
+
+class PingHandler(basic.BaseHandler):
+    def process_get(self, params):
+        self.write('Pong')
+        self.write(json.dumps(params))
+        self.finish('OK')
+
+    def process_head(self, params):
+        self.write(json.dumps(params))
+        self.finish('OK')
+
+    config = {
+        'GET': {
+            'params': {
+                'token': {
+                    'type': 'string',
+                    'default': None
+                    }
+                },
+            'function': 'process_get'
+            },
+        'HEAD': {
+            'params': None,
+            'function': 'process_head'
+            }
+        }

--- a/data/data.py
+++ b/data/data.py
@@ -12,6 +12,7 @@ import app.housing
 import app.auth
 import app.documentation
 
+import api.config as apiconfig
 
 class Application(tornado.web.Application):
     def __init__(self, debug=False):
@@ -29,29 +30,17 @@ class Application(tornado.web.Application):
 
         handlers = [
             (r"/$", app.main.MainHandler),
-            (r"/ping$", PingHandler),
-            (r"/courses$", app.courses.CoursesHandler),
-            (r"/courses/v2/courses$", app.courses_v2.CoursesV2Handler),
-            (r"/courses/v2/sections$", app.courses_v2.SectionsV2Handler),
-            (r"/courses/v2/search$", app.courses_v2.FullTextSearchHandler),
-            (r"/housing/rooms$", app.housing.RoomHandler),
-            (r"/housing/buildings$", app.housing.BuildingHandler),
+            ]
+        handlers = handlers + apiconfig.api_handlers()
+        handlers = handlers + [
             (r"/docs$", app.main.MainHandler),
             (r"/docs/([^/]+)", app.documentation.DocsHandler),
             (r"/login$", app.auth.LoginHandler),
             (r"/logout$", app.auth.LogoutHandler),
             (r"/profile$", app.main.ProfileHandler),
-
         ]
         debug = True
         tornado.web.Application.__init__(self, handlers, **app_settings)
-
-class PingHandler(tornado.web.RequestHandler):
-    def get(self):
-        self.finish('OK')
-    def head(self):
-        self.finish('OK')
-
 
 if __name__ == "__main__":
     # this port should be unique system wide; all ports used should be listed in ~/services.py


### PR DESCRIPTION
1. api/config.py specifies routes and api call configs
2. generalized support for non-GET calls
3. 'help' param in any API call gives you list of valid GET params
4. programmatically generate up-to-date API RPC interface
