### PR TITLE
fixes housing query option

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,4 +1,4 @@
-Flask
+flask
 psycopg2
 nose
 redis

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,4 +1,4 @@
-flask
+Flask
 psycopg2
 nose
 redis

--- a/data/housing/housing.py
+++ b/data/housing/housing.py
@@ -88,9 +88,7 @@ def options(attr):
     """
     if attr not in room_attributes:
         raise errors.AppError('INVALID_ATTRIBUTE', attr_name=attr)
-    # strip the dictionary down to the releveant attribute
-    relevant_values = {attr: room_attributes[attr]}
-    pg_query, values = query.build_query(TABLE, relevant_values)
+    pg_query, values = query.build_query(TABLE, room_attributes, option=attr)
     g.cursor.execute(pg_query, values)
     results = g.cursor.fetchall()
     if not len(results):    # no results, shouldn't be called

--- a/data/lib/query.py
+++ b/data/lib/query.py
@@ -12,19 +12,19 @@ from flask import request
 PG_LIMIT = environ['PG_LIMIT']
 
 
-def build_where_statement(attr_converter):
+def build_where_statement(config_dict):
     """
     Combines the querystring params into a WHERE statement for the sql query.
 
-    @param attr_converter: dict with column names and converter functions
+    @param config_dict: dict with column names and converter functions
     """
     statements = []
     values = []
     # iterate over the querystring params
     for attr, val in request.args.iteritems():
         try:
-            statements.append(attr_converter[attr]['converter'](
-                attr_converter[attr]['column']))
+            statements.append(config_dict[attr]['converter'](
+                config_dict[attr]['column']))
             values.append(val)  # add after the possible keyerror
         except KeyError:
             raise errors.AppError('INVALID_ATTRIBUTE', attr_name=attr)
@@ -33,22 +33,29 @@ def build_where_statement(attr_converter):
     return '', []
 
 
-def build_query(table, attr_converter, page=0):
+def build_query(table, config_dict, option=None, page=0):
     """
     Constructs a pg sql query based on the table and given querystring.
 
     @param table: string name of the queried table
-    @param attr_converter: dictionary of (querystring key -> database column)
+    @param config_dict: dictionary of (querystring key -> database column)
     @param page: page of the results to return (only used when a query has
         > PG_LIMIT results)
     """
-    where_statement, values = build_where_statement(attr_converter)
+    if option:
+        select_statement = '{} AS {}'.format(config_dict[option]['column'], option)
+    else:
+        select_statement = ', '.join(['{} AS {}'.format(config_dict[col]['column'], col)
+            for col in config_dict])
+
+    where_statement, values = build_where_statement(config_dict)
+    print where_statement
     query = "SELECT DISTINCT {} FROM {} {} LIMIT {} OFFSET {};".format(
-        ', '.join(['{} AS {}'.format(attr_converter[col]['column'], col)
-            for col in attr_converter]),
+        select_statement,       # columns to select
         table,                  # db table
         where_statement,        # various statements to narrow search results
         PG_LIMIT,               # number of rows to return
         int(PG_LIMIT)*page      # number or rows to skip
     )
+    print query
     return query, values

--- a/data/tests/test_housing.py
+++ b/data/tests/test_housing.py
@@ -40,3 +40,13 @@ class TestHousingRoutes(template.TestingTemplate):
         resp = self.app.get('/housing/rooms/options/{}'.format(attr))
         self.check_error(resp, 'INVALID_ATTRIBUTE',
                          options={'attr_name': attr})
+
+    def test_rooms_options_valid_query_parameter(self):
+        """ test that the response is valid for an options request with query parameter """
+        resp = self.app.get('/housing/rooms/options/room_type?room_area=200')
+        json_resp = json.loads(resp.data)
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(200, json_resp['status'])
+        self.assertEqual(len(json_resp['results']), 9)
+
+


### PR DESCRIPTION
housing test started in housing.py, line 43, function _test_rooms_options_valid_query_parameter_.

the whole _room_attributes_ dictionary should now be being passed into the _pg_query_ builder.

@natebrennand helped with constructing it and said I should pull request it here.
