### PR TITLE
add user creation/login

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,5 +1,7 @@
-Flask
-psycopg2
-nose
-redis
-Flask_OAuth
+Flask==0.10.1
+Flask-OAuth==0.12
+mock==1.0.1
+nose==1.3.0
+psycopg2==2.5.2
+redis==2.9.0
+requests==2.2.1

--- a/data/auth/auth.py
+++ b/data/auth/auth.py
@@ -5,12 +5,13 @@ from os import path, environ
 import sys
 import requests
 
-import user
-
 # add the parent directory for in-project imports
 base_dir = path.abspath(path.join(path.dirname(path.abspath(__file__)), '..'))
 if base_dir not in sys.path:
     sys.path.append(base_dir)
+
+import user
+from errors import errors
 
 auth_blueprint = Blueprint('auth_blueprint', __name__)
 
@@ -57,6 +58,10 @@ def authorized(resp):
 
     # get user info from Google People API
     profile = requests.get(GOOGLE_PEOPLE_URL.format(token=access_token))
+
+    if profile.status_code != 200:
+        raise errors.AppError("GOOGLE_AUTH_FAILURE")
+
     user_email, user_name = profile.json()['email'], profile.json()['name']
 
     # retrive/create user token

--- a/data/auth/auth.py
+++ b/data/auth/auth.py
@@ -3,6 +3,9 @@ from flask import Blueprint, session, redirect, url_for
 from flask_oauth import OAuth
 from os import path, environ
 import sys
+import requests
+
+import user
 
 # add the parent directory for in-project imports
 base_dir = path.abspath(path.join(path.dirname(path.abspath(__file__)), '..'))
@@ -15,6 +18,9 @@ GOOGLE_CLIENT_ID = environ['GOOGLE_CLIENT_ID']
 GOOGLE_CLIENT_SECRET = environ['GOOGLE_CLIENT_SECRET']
 # one of the Redirect URIs from Google APIs console
 REDIRECT_URI = environ['REDIRECT_URI']
+
+GOOGLE_PEOPLE_URL = ("https://www.googleapis.com/oauth2/v1/userinfo?"
+                     "access_token={token}")
 
 
 oauth = OAuth()
@@ -48,6 +54,13 @@ def login():
 @google.authorized_handler
 def authorized(resp):
     access_token = resp['access_token']
-    session['google_token'] = access_token
-    # Create DB record here
-    return redirect('/')
+
+    # get user info from Google People API
+    profile = requests.get(GOOGLE_PEOPLE_URL.format(token=access_token))
+    user_email, user_name = profile.json()['email'], profile.json()['name']
+
+    # retrive/create user token
+    user_token = user.get_user(user_email, user_name)
+    session['token'] = user_token
+
+    return redirect(url_for('home'))

--- a/data/auth/user.py
+++ b/data/auth/user.py
@@ -1,0 +1,40 @@
+
+from struct import unpack
+from flask import g
+from os import urandom
+
+
+GET_USER = "SELECT * FROM users_t WHERE email = %s;"
+INSERT_USER = ('INSERT INTO users_t (email, token, name) '
+               'VALUES (%s, %s, %s);')
+
+
+def generate_token():
+    """ Generate a random integer for a token.
+
+    We use os.urandom() to create the token securely and struct.unpack() to
+    create an unsigned long long from the random bytes. "<Q" corresponds to an
+    unsigned long.
+    """
+    return unpack("<Q", urandom(8))[0]
+
+
+def create_user(email, name):
+    """ creates a new API consumer """
+    user_token = generate_token()
+    g.cursor.execute(INSERT_USER, [email, user_token, name])
+    g.pg_conn.commit()
+    return user_token
+
+
+def get_user(email, name):
+    """ returns a users's ID given an email
+
+    If the user does not exist a new user record is created.
+    """
+    g.cursor.execute(GET_USER, [email])
+    user = g.cursor.fetchone()
+    if user:
+        return user['token']
+    else:
+        return create_user(email, name)

--- a/data/data.py
+++ b/data/data.py
@@ -8,6 +8,7 @@ import redis
 
 # project libraries
 from errors import errors
+from auth import user
 
 # blueprint imports
 from housing.housing import housing as housing_blueprint
@@ -57,6 +58,7 @@ app.register_error_handler(404, errors.handle_404_error)
 
 
 """ Blueprints """
+housing_blueprint.before_request(user.valid_token)  # add auth to housing
 app.register_blueprint(housing_blueprint, url_prefix='/housing')
 app.register_blueprint(auth_blueprint, url_prefix='')
 

--- a/data/data.py
+++ b/data/data.py
@@ -6,8 +6,9 @@ import psycopg2.pool
 import psycopg2.extras
 import redis
 
-
+# project libraries
 from errors import errors
+
 # blueprint imports
 from housing.housing import housing as housing_blueprint
 from auth.auth import auth_blueprint

--- a/data/errors/definitions.json
+++ b/data/errors/definitions.json
@@ -40,5 +40,10 @@
         "status": 401,
         "message": "your token was not found in our system",
         "default_options": {}
+    },
+    "GOOGLE_AUTH_FAILURE": {
+        "status": 400,
+        "message": "your token was not found in our system",
+        "default_options": {}
     }
 }

--- a/data/errors/definitions.json
+++ b/data/errors/definitions.json
@@ -30,5 +30,15 @@
         "default_options": {
             "attr_name": "Your parameter"
         }
+    },
+    "NO_TOKEN": {
+        "status": 401,
+        "message": "this endpoint requires a token for access",
+        "default_options": {}
+    },
+    "INVALID_TOKEN": {
+        "status": 401,
+        "message": "your token was not found in our system",
+        "default_options": {}
     }
 }

--- a/data/lib/query.py
+++ b/data/lib/query.py
@@ -47,7 +47,8 @@ def build_where_statement(config_dict):
                 config_dict[attr]['column']))
             values.append(val)  # add after the possible keyerror
         except KeyError:
-            raise errors.AppError('INVALID_ATTRIBUTE', attr_name=attr)
+            if attr != 'token':
+                raise errors.AppError('INVALID_ATTRIBUTE', attr_name=attr)
     if statements:
         return 'WHERE '+' AND '.join(statements), values
     return '', []

--- a/data/tests/template.py
+++ b/data/tests/template.py
@@ -21,9 +21,7 @@ class TestingTemplate(unittest.TestCase):
         """ Instantiates a test instance of the app before each test """
         self.app = data.app.test_client()
         r = redis.Redis(connection_pool=data.redis_pool)
-        r.hmset(test_token, {
-                'email': test_email,
-                'name': test_user})
+        r.sadd('tokens', test_token)
 
     def check_error(self, resp, error_name, options=None):
         """ Tests that the resp is equal to the specified error """

--- a/data/tests/template.py
+++ b/data/tests/template.py
@@ -22,3 +22,22 @@ class TestingTemplate(unittest.TestCase):
         self.assertEqual(
             json.loads(resp.data)['message'],
             expected_error['message'].format(**options))
+
+
+class MockingTemplate(unittest.TestCase):
+
+    def check_query(self, obj, expected_query, expected_values):
+        """ check a mocked query was called correctly """
+        query, values =  obj.call_args[0]
+        self.assertEqual(query, expected_query)
+        for i, val in enumerate(expected_values):
+            self.assertEqual(values[i], val)
+
+
+    def check_queries(self, obj, expected_queries, expected_values):
+        """ check a mocked query was called correctly """
+        for j, args in enumerate(obj.call_args_list):
+            query, values = args[0][0], args[0][1]
+            self.assertEqual(query, expected_queries[j])
+            for i, val in enumerate(expected_values[j]):
+                self.assertEqual(values[i], val)

--- a/data/tests/template.py
+++ b/data/tests/template.py
@@ -1,16 +1,28 @@
 
 import unittest
 import json
-from data import app
+import data
 from errors import errors
+import redis
 
+
+test_email, test_user, test_token = 'test@test.com', 'tester', '12345'
+test_record = {
+    'email': test_email,
+    'token': test_token,
+    'name': test_user
+}
 
 class TestingTemplate(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
         """ Instantiates a test instance of the app before each test """
-        self.app = app.test_client()
+        self.app = data.app.test_client()
+        r = redis.Redis(connection_pool=data.redis_pool)
+        r.hmset(test_token, {
+                           'email': test_email,
+                           'name': test_user})
 
     def check_error(self, resp, error_name, options=None):
         """ Tests that the resp is equal to the specified error """

--- a/data/tests/template.py
+++ b/data/tests/template.py
@@ -28,11 +28,10 @@ class MockingTemplate(unittest.TestCase):
 
     def check_query(self, obj, expected_query, expected_values):
         """ check a mocked query was called correctly """
-        query, values =  obj.call_args[0]
+        query, values = obj.call_args[0]
         self.assertEqual(query, expected_query)
         for i, val in enumerate(expected_values):
             self.assertEqual(values[i], val)
-
 
     def check_queries(self, obj, expected_queries, expected_values):
         """ check a mocked query was called correctly """

--- a/data/tests/template.py
+++ b/data/tests/template.py
@@ -13,6 +13,7 @@ test_record = {
     'name': test_user
 }
 
+
 class TestingTemplate(unittest.TestCase):
 
     @classmethod
@@ -21,8 +22,8 @@ class TestingTemplate(unittest.TestCase):
         self.app = data.app.test_client()
         r = redis.Redis(connection_pool=data.redis_pool)
         r.hmset(test_token, {
-                           'email': test_email,
-                           'name': test_user})
+                'email': test_email,
+                'name': test_user})
 
     def check_error(self, resp, error_name, options=None):
         """ Tests that the resp is equal to the specified error """

--- a/data/tests/test_housing.py
+++ b/data/tests/test_housing.py
@@ -34,15 +34,16 @@ class TestHousingRoutes(template.TestingTemplate):
     def test_rooms_options_invalid_attribute(self):
         """ test that an error is returned with an invalid attribute """
         attr = 'fake_attr'
-        resp = self.app.get('/housing/rooms/options/{}?token=12345'.format(attr))
+        resp = self.app.get(
+            '/housing/rooms/options/{}?token=12345'.format(attr))
         self.check_error(resp, 'INVALID_ATTRIBUTE',
                          options={'attr_name': attr})
 
         attr = 'another_fake_attr'
-        resp = self.app.get('/housing/rooms/options/{}?token=12345'.format(attr))
+        resp = self.app.get(
+            '/housing/rooms/options/{}?token=12345'.format(attr))
         self.check_error(resp, 'INVALID_ATTRIBUTE',
                          options={'attr_name': attr})
-
 
     def test_rooms_options_no_query_parameter_invalid_token(self):
         """

--- a/data/tests/test_housing.py
+++ b/data/tests/test_housing.py
@@ -7,7 +7,8 @@ class TestHousingRoutes(template.TestingTemplate):
 
     def test_rooms_two_valid_attr(self):
         """ test query for /rooms with 2 valid attr """
-        resp = self.app.get('/housing/rooms?is_suite=false&point_value=10')
+        resp = self.app.get(
+            '/housing/rooms?is_suite=false&point_value=10&token=12345')
         json_resp = json.loads(resp.data)
         self.assertEqual(200, resp.status_code)
         self.assertEqual(200, json_resp['status'])
@@ -15,15 +16,16 @@ class TestHousingRoutes(template.TestingTemplate):
 
     def test_rooms_page_too_far(self):
         """ test that an error is returned after paging too far """
-        resp = self.app.get('/housing/rooms/5?is_suite=false&point_value=10')
+        resp = self.app.get(
+            '/housing/rooms/5?is_suite=false&point_value=10&token=12345')
         self.check_error(resp, 'NO_RESULTS')
 
-        resp = self.app.get('/housing/rooms/100')
+        resp = self.app.get('/housing/rooms/100?token=12345')
         self.check_error(resp, 'NO_RESULTS')
 
     def test_rooms_options_valid_attribute(self):
         """ test that the response is valid for an options request """
-        resp = self.app.get('/housing/rooms/options/room_type')
+        resp = self.app.get('/housing/rooms/options/room_type?token=12345')
         json_resp = json.loads(resp.data)
         self.assertEqual(200, resp.status_code)
         self.assertEqual(200, json_resp['status'])
@@ -32,21 +34,34 @@ class TestHousingRoutes(template.TestingTemplate):
     def test_rooms_options_invalid_attribute(self):
         """ test that an error is returned with an invalid attribute """
         attr = 'fake_attr'
-        resp = self.app.get('/housing/rooms/options/{}'.format(attr))
+        resp = self.app.get('/housing/rooms/options/{}?token=12345'.format(attr))
         self.check_error(resp, 'INVALID_ATTRIBUTE',
                          options={'attr_name': attr})
 
         attr = 'another_fake_attr'
-        resp = self.app.get('/housing/rooms/options/{}'.format(attr))
+        resp = self.app.get('/housing/rooms/options/{}?token=12345'.format(attr))
         self.check_error(resp, 'INVALID_ATTRIBUTE',
                          options={'attr_name': attr})
+
+
+    def test_rooms_options_no_query_parameter_invalid_token(self):
+        """
+        Test that the response is valid for an options request w/o querystring
+        filtering
+        """
+        resp = self.app.get('/housing/rooms/options/room_type')
+        self.check_error(resp, 'NO_TOKEN')
+
+        resp = self.app.get(
+            '/housing/rooms/options/room_type?token=false')
+        self.check_error(resp, 'INVALID_TOKEN')
 
     def test_rooms_options_no_query_parameter(self):
         """
         Test that the response is valid for an options request w/o querystring
         filtering
         """
-        resp = self.app.get('/housing/rooms/options/room_type')
+        resp = self.app.get('/housing/rooms/options/room_type?token=12345')
         json_resp = json.loads(resp.data)
         self.assertEqual(200, resp.status_code)
         self.assertEqual(200, json_resp['status'])
@@ -57,7 +72,8 @@ class TestHousingRoutes(template.TestingTemplate):
         Test that the response is valid for an options request with query
         parameter
         """
-        resp = self.app.get('/housing/rooms/options/room_type?room_area=200')
+        resp = self.app.get(
+            '/housing/rooms/options/room_type?room_area=200&token=12345')
         json_resp = json.loads(resp.data)
         self.assertEqual(200, resp.status_code)
         self.assertEqual(200, json_resp['status'])

--- a/data/tests/test_user.py
+++ b/data/tests/test_user.py
@@ -1,0 +1,83 @@
+
+from mock import patch
+from template import MockingTemplate
+
+from auth import user
+
+test_email, test_user, test_token = 'test@test.com', 'tester', '12345'
+test_record = {
+    'email': test_email,
+    'token': test_token,
+    'name': test_user 
+}
+
+
+class TestUser(MockingTemplate):
+
+
+    def test_generate_token(self):
+        """ test that it is supported by the system """
+        user.generate_token()
+
+
+    @patch.object(user, 'generate_token')
+    @patch.object(user, 'g')
+    def test_create_user(self, mock_g, mock_token):
+        """ test that create_user() calls the db correctly """
+        mock_token.return_value = test_token
+        outcome = user.create_user(test_email, test_user)
+
+        # check return token
+        self.assertEqual(outcome, test_token)
+
+        # check that the correct query was called
+        self.check_query(mock_g.cursor.execute,
+            'INSERT INTO users_t (email, token, name) VALUES (%s, %s, %s);',
+            [test_email, test_token, test_user]
+        )
+        # check that commit() was called
+        self.assertTrue(mock_g.pg_conn.commit.called)
+
+
+    @patch.object(user, 'g')
+    def test_get_existing_user(self, mock_g):
+        """ test that get_user() calls the db correctly with existing users """
+        mock_g.cursor.fetchone.return_value = test_record
+        outcome = user.get_user(test_email, test_user)
+
+        # check return val
+        self.assertEqual(outcome, test_token)
+
+        # check that the correct query was called
+        self.check_query(mock_g.cursor.execute,
+            'SELECT * FROM users_t WHERE email = %s;',
+            [test_email]
+        )
+
+        # check that commit() was called
+        self.assertTrue(mock_g.cursor.fetchone.called)
+
+
+    @patch.object(user, 'generate_token')
+    @patch.object(user, 'g')
+    def test_get_new_user(self, mock_g, mock_token):
+        """ test that get_user() operates correctly with new users """
+        mock_token.return_value = test_token
+
+        mock_g.cursor.fetchone.return_value = None
+        outcome = user.get_user(test_email, test_user)
+
+        # check return val
+        self.assertEqual(outcome, test_token)
+
+        self.check_queries(mock_g.cursor.execute, [
+            'SELECT * FROM users_t WHERE email = %s;',
+            'INSERT INTO users_t (email, token, name) VALUES (%s, %s, %s);',],
+            [[test_email], [test_email, test_token, test_user]]
+        )
+
+        # check that commit() was called
+        self.assertTrue(mock_g.pg_conn.commit.called)
+
+        # check that commit() was called
+        self.assertTrue(mock_g.cursor.fetchone.called)

--- a/data/tests/test_user.py
+++ b/data/tests/test_user.py
@@ -8,17 +8,15 @@ test_email, test_user, test_token = 'test@test.com', 'tester', '12345'
 test_record = {
     'email': test_email,
     'token': test_token,
-    'name': test_user 
+    'name': test_user
 }
 
 
 class TestUser(MockingTemplate):
 
-
     def test_generate_token(self):
         """ test that it is supported by the system """
         user.generate_token()
-
 
     @patch.object(user, 'generate_token')
     @patch.object(user, 'g')
@@ -31,13 +29,13 @@ class TestUser(MockingTemplate):
         self.assertEqual(outcome, test_token)
 
         # check that the correct query was called
-        self.check_query(mock_g.cursor.execute,
+        self.check_query(
+            mock_g.cursor.execute,
             'INSERT INTO users_t (email, token, name) VALUES (%s, %s, %s);',
             [test_email, test_token, test_user]
         )
         # check that commit() was called
         self.assertTrue(mock_g.pg_conn.commit.called)
-
 
     @patch.object(user, 'g')
     def test_get_existing_user(self, mock_g):
@@ -49,14 +47,14 @@ class TestUser(MockingTemplate):
         self.assertEqual(outcome, test_token)
 
         # check that the correct query was called
-        self.check_query(mock_g.cursor.execute,
+        self.check_query(
+            mock_g.cursor.execute,
             'SELECT * FROM users_t WHERE email = %s;',
             [test_email]
         )
 
         # check that commit() was called
         self.assertTrue(mock_g.cursor.fetchone.called)
-
 
     @patch.object(user, 'generate_token')
     @patch.object(user, 'g')
@@ -70,9 +68,10 @@ class TestUser(MockingTemplate):
         # check return val
         self.assertEqual(outcome, test_token)
 
-        self.check_queries(mock_g.cursor.execute, [
-            'SELECT * FROM users_t WHERE email = %s;',
-            'INSERT INTO users_t (email, token, name) VALUES (%s, %s, %s);',],
+        self.check_queries(
+            mock_g.cursor.execute,
+            ['SELECT * FROM users_t WHERE email = %s;',
+             'INSERT INTO users_t (email, token, name) VALUES (%s, %s, %s);'],
             [[test_email], [test_email, test_token, test_user]]
         )
 

--- a/data/tests/test_user.py
+++ b/data/tests/test_user.py
@@ -25,7 +25,7 @@ class TestUser(MockingTemplate):
     def test_create_user(self, mock_g, mock_token):
         """ test that create_user() calls the db correctly """
         mock_token.return_value = test_token
-        mock_g.redis.exists.return_value = False
+        mock_g.redis.sismember.return_value = False
         outcome = user.create_user(test_email, test_user)
 
         # check return token
@@ -65,7 +65,7 @@ class TestUser(MockingTemplate):
         """ test that get_user() operates correctly with new users """
         mock_token.return_value = test_token
         mock_g.cursor.fetchone.return_value = None
-        mock_g.redis.exists.return_value = False
+        mock_g.redis.sismember.return_value = False
 
         outcome = user.get_user(test_email, test_user)
 
@@ -95,12 +95,12 @@ class TestUser(MockingTemplate):
             with app.test_request_context('/'):
                 user.valid_token()
 
-        mock_g.redis.exists.return_value = False
+        mock_g.redis.sismember.return_value = False
         with app.test_request_context('/?token=123'):
             with self.assertRaises(errors.AppError):
                 user.valid_token()
 
-        mock_g.redis.exists.return_value = True
+        mock_g.redis.sismember.return_value = True
         with app.test_request_context('/?token=123'):
             # don't try to catch error
             user.valid_token()

--- a/data/tests/test_user.py
+++ b/data/tests/test_user.py
@@ -23,6 +23,7 @@ class TestUser(MockingTemplate):
     def test_create_user(self, mock_g, mock_token):
         """ test that create_user() calls the db correctly """
         mock_token.return_value = test_token
+        mock_g.redis.exists.return_value = False
         outcome = user.create_user(test_email, test_user)
 
         # check return token
@@ -61,8 +62,9 @@ class TestUser(MockingTemplate):
     def test_get_new_user(self, mock_g, mock_token):
         """ test that get_user() operates correctly with new users """
         mock_token.return_value = test_token
-
         mock_g.cursor.fetchone.return_value = None
+        mock_g.redis.exists.return_value = False
+
         outcome = user.get_user(test_email, test_user)
 
         # check return val

--- a/dev/dev_dump.sql
+++ b/dev/dev_dump.sql
@@ -3202,6 +3202,7 @@ REVOKE ALL ON TABLE housing_t FROM PUBLIC;
 REVOKE ALL ON TABLE housing_t FROM postgres;
 GRANT ALL ON TABLE housing_t TO postgres;
 GRANT SELECT ON TABLE housing_t TO adi;
+GRANT ALL ON TABLE users_t TO adi;
 
 
 --


### PR DESCRIPTION
object mocking for tests took so long to grok :triumph:

After going through oauth, if a user record is not found then one is created.
Creates a record in redis and the postgres database for a user using their email, name (via google) and a randomly generated token. We're still using the old schema for the users table, `users_t`.

The auth decorator can be applied to the blueprint before [registering](https://github.com/natebrennand/data.adicu.com/blob/master/data/data.py#L61) it in `data.py`.
Finishes #53.
