### PR TITLE
basic rate limiting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,6 @@ script:
     - flake8 data/housing
     - flake8 data/tests
     - flake8 data/data.py
+    - flake8 data/lib/query.py
+    - flake8 data/lib/converters.py
     - cd data && nosetests -sv tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - PG_DB=travis_test
     - PG_LIMIT=250
     - PG_DEFAULT=20
+    - RATE_LIMIT=200
 
     - REDIS_HOST=0.0.0.0
     - REDIS_PORT=6379

--- a/config/settings.dev
+++ b/config/settings.dev
@@ -15,6 +15,7 @@ export PG_PASSWORD=adi
 export PG_DB=data2
 export PG_LIMIT=250
 export PG_DEFAULT=20
+export RATE_LIMIT=200   # 60 minute window
 
 # Redis connection
 export REDIS_HOST=localhost
@@ -25,4 +26,3 @@ export REDIS_DB=1
 export GOOGLE_CLIENT_ID=client_id_here
 export GOOGLE_CLIENT_SECRET=client_secret_here
 export REDIRECT_URI=authorized
-

--- a/data/auth/user.py
+++ b/data/auth/user.py
@@ -56,7 +56,7 @@ def get_user(email, name):
         return create_user(email, name)
 
 
-def valid_token():
+def check_token_validity():
     """ decorator for authenticated endpoints """
     if 'token' not in request.args:
         raise errors.AppError("NO_TOKEN")
@@ -68,7 +68,7 @@ def valid_token():
 
 def rate_limit():
     """ limits the user to a set number of requests per 15 minutes """
-    valid_token()   # check the token
+    check_token_validity()   # check the token
     req_token = request.args['token']
     key = "rate:{}".format(req_token)
 

--- a/data/auth/user.py
+++ b/data/auth/user.py
@@ -1,7 +1,7 @@
 
 from struct import unpack
 from flask import g, request
-from os import urandom, path
+from os import urandom, path, environ
 import sys
 
 # add the parent directory for in-project imports
@@ -12,9 +12,10 @@ from errors import errors
 
 
 GET_USER = "SELECT * FROM users_t WHERE email = %s;"
-INSERT_USER = ('INSERT INTO users_t (email, token, name) '
-               'VALUES (%s, %s, %s);')
+INSERT_USER = ('INSERT INTO users_t (email, token, name, limit) '
+               'VALUES (%s, %s, %s, %s);')
 TOKENS = 'tokens'
+DEFAULT_LIMIT = environ['RATE_LIMIT']
 
 
 def generate_token():
@@ -34,7 +35,7 @@ def create_user(email, name):
         user_token = generate_token()
 
     g.redis.sadd(TOKENS, user_token)
-    g.cursor.execute(INSERT_USER, [email, user_token, name])
+    g.cursor.execute(INSERT_USER, [email, user_token, name, DEFAULT_LIMIT])
     g.pg_conn.commit()
 
     return user_token

--- a/data/auth/user.py
+++ b/data/auth/user.py
@@ -11,11 +11,13 @@ if base_dir not in sys.path:
 from errors import errors
 
 
-GET_USER = "SELECT * FROM users_t WHERE email = %s;"
-INSERT_USER = ('INSERT INTO users_t (email, token, name, limit) '
+GET_USER_EMAIL = "SELECT * FROM users_t WHERE email = %s;"
+GET_USER_TOKEN = "SELECT * FROM users_t WHERE token = CAST(%s as TEXT);"
+INSERT_USER = ('INSERT INTO users_t (email, token, name, rate_limit) '
                'VALUES (%s, %s, %s, %s);')
 TOKENS = 'tokens'
 DEFAULT_LIMIT = environ['RATE_LIMIT']
+SPLIT_FACTOR = 4    # how to split the hour's api hits
 
 
 def generate_token():
@@ -46,7 +48,7 @@ def get_user(email, name):
 
     If the user does not exist a new user record is created.
     """
-    g.cursor.execute(GET_USER, [email])
+    g.cursor.execute(GET_USER_EMAIL, [email])
     user = g.cursor.fetchone()
     if user and g.redis.sismember(TOKENS, user['token']):
         return user['token']
@@ -62,3 +64,22 @@ def valid_token():
     req_token = request.args['token']
     if not g.redis.sismember(TOKENS, req_token):
         raise errors.AppError("INVALID_TOKEN")
+
+
+def rate_limit():
+    """ limits the user to a set number of requests per 15 minutes """
+    req_token = request.args['token']
+    key = "rate:{}".format(req_token)
+
+    # confirm key exists, if not instantiate
+    if not g.redis.exists(key):
+        g.cursor.execute(GET_USER_TOKEN, [req_token])
+        user = g.cursor.fetchone()
+        g.redis.setex(key, int(user['rate_limit'])/SPLIT_FACTOR,
+                      60*60/SPLIT_FACTOR)
+
+    # return error if being limited
+    if int(g.redis.get(key)) <= 0:
+        raise errors.AppError("RATE_LIMIT")
+
+    g.redis.decr(key)

--- a/data/auth/user.py
+++ b/data/auth/user.py
@@ -68,6 +68,7 @@ def valid_token():
 
 def rate_limit():
     """ limits the user to a set number of requests per 15 minutes """
+    valid_token()   # check the token
     req_token = request.args['token']
     key = "rate:{}".format(req_token)
 

--- a/data/data.py
+++ b/data/data.py
@@ -58,7 +58,6 @@ app.register_error_handler(404, errors.handle_404_error)
 
 
 """ Blueprints """
-housing_blueprint.before_request(user.valid_token)  # add auth to housing
 housing_blueprint.before_request(user.rate_limit)   # add rate limiting
 app.register_blueprint(housing_blueprint, url_prefix='/housing')
 app.register_blueprint(auth_blueprint, url_prefix='')

--- a/data/data.py
+++ b/data/data.py
@@ -59,6 +59,7 @@ app.register_error_handler(404, errors.handle_404_error)
 
 """ Blueprints """
 housing_blueprint.before_request(user.valid_token)  # add auth to housing
+housing_blueprint.before_request(user.rate_limit)   # add rate limiting
 app.register_blueprint(housing_blueprint, url_prefix='/housing')
 app.register_blueprint(auth_blueprint, url_prefix='')
 

--- a/data/data.py
+++ b/data/data.py
@@ -10,13 +10,13 @@ import redis
 from errors import errors
 from auth import user
 
+app = Flask(__name__)
+app.config.from_object('config.flask_config')
+
 # blueprint imports
 from housing.housing import housing as housing_blueprint
 from auth.auth import auth_blueprint
 
-
-app = Flask(__name__)
-app.config.from_object('config.flask_config')
 
 pg_pool = psycopg2.pool.SimpleConnectionPool(
     5,      # min connections

--- a/data/errors/definitions.json
+++ b/data/errors/definitions.json
@@ -43,7 +43,12 @@
     },
     "GOOGLE_AUTH_FAILURE": {
         "status": 400,
-        "message": "your token was not found in our system",
+        "message": "there was an error authenticating with Google, please try again",
+        "default_options": {}
+    },
+    "RATE_LIMIT": {
+        "status": 429,
+        "message": "you've run out of requests for this hour",
         "default_options": {}
     }
 }

--- a/data/lib/query.py
+++ b/data/lib/query.py
@@ -14,7 +14,7 @@ PG_LIMIT = int(environ['PG_LIMIT'])
 
 def build_select_statemnt(config_dict, option=None):
     """
-    Buildings the select statement based on the config_dict passed in. If 
+    Buildings the select statement based on the config_dict passed in. If
     option is instantiated then only that column will be returned.
     """
     if option:

--- a/data/tests/template.py
+++ b/data/tests/template.py
@@ -24,6 +24,13 @@ class TestingTemplate(unittest.TestCase):
         self.r.sadd('tokens', test_token)
         self.r.sadd('tokens', 'integration_test')
 
+    @classmethod
+    def tearDownClass(self):
+        """ clean up Redis """
+        self.r.delete('tokens', test_token)
+        self.r.delete('rate:12345')
+        self.r.delete('rate:integration_test')
+
     def check_error(self, resp, error_name, options=None):
         """ Tests that the resp is equal to the specified error """
         expected_error = errors.error_definitions[error_name]

--- a/data/tests/template.py
+++ b/data/tests/template.py
@@ -20,8 +20,9 @@ class TestingTemplate(unittest.TestCase):
     def setUpClass(self):
         """ Instantiates a test instance of the app before each test """
         self.app = data.app.test_client()
-        r = redis.Redis(connection_pool=data.redis_pool)
-        r.sadd('tokens', test_token)
+        self.r = redis.Redis(connection_pool=data.redis_pool)
+        self.r.sadd('tokens', test_token)
+        self.r.sadd('tokens', 'integration_test')
 
     def check_error(self, resp, error_name, options=None):
         """ Tests that the resp is equal to the specified error """

--- a/data/tests/test_user.py
+++ b/data/tests/test_user.py
@@ -91,26 +91,26 @@ class TestUser(MockingTemplate):
     def test_valid_token_decorator(self, mock_g):
         """ test that the decorator throws errors appropriately """
         app = flask.Flask(__name__)
-        app.before_request(user.valid_token)
+        app.before_request(user.check_token_validity)
 
         with self.assertRaises(errors.AppError):
             with app.test_request_context('/'):
-                user.valid_token()
+                user.check_token_validity()
 
         mock_g.redis.sismember.return_value = False
         with app.test_request_context('/?token=123'):
             with self.assertRaises(errors.AppError):
-                user.valid_token()
+                user.check_token_validity()
 
         mock_g.redis.sismember.return_value = True
         with app.test_request_context('/?token=123'):
-            user.valid_token()
+            user.check_token_validity()
 
     @patch.object(user, 'g')
     def test_rate_limit_mocking(self, mock_g):
         """ test that Redis methods are called at appropriate times """
         app = flask.Flask(__name__)
-        app.before_request(user.valid_token)
+        app.before_request(user.check_token_validity)
 
         # test the key is created properly
         mock_g.redis.sismember.return_value = True

--- a/data/tests/test_user.py
+++ b/data/tests/test_user.py
@@ -2,23 +2,23 @@
 from mock import patch
 import flask
 
-from template import MockingTemplate
+from template import MockingTemplate, TestingTemplate
 from auth import user
 from errors import errors
 
-test_email, test_user, test_token = 'test@test.com', 'tester', '12345'
+test_email = 'test@test.com'
+test_user = 'tester'
+test_token = '12345'
+test_rate_limit = 100
 test_record = {
     'email': test_email,
     'token': test_token,
-    'name': test_user
+    'name': test_user,
+    'rate_limit': test_rate_limit
 }
 
 
 class TestUser(MockingTemplate):
-
-    def test_generate_token(self):
-        """ test that it is supported by the system """
-        user.generate_token()
 
     @patch.object(user, 'generate_token')
     @patch.object(user, 'g')
@@ -88,10 +88,10 @@ class TestUser(MockingTemplate):
         self.assertTrue(mock_g.cursor.fetchone.called)
 
     @patch.object(user, 'g')
-    def test_valid_token_dec(self, mock_g):
+    def test_valid_token_decorator(self, mock_g):
         """ test that the decorator throws errors appropriately """
         app = flask.Flask(__name__)
-        #app.before_request(user.valid_token)
+        app.before_request(user.valid_token)
 
         with self.assertRaises(errors.AppError):
             with app.test_request_context('/'):
@@ -104,5 +104,49 @@ class TestUser(MockingTemplate):
 
         mock_g.redis.sismember.return_value = True
         with app.test_request_context('/?token=123'):
-            # don't try to catch error
             user.valid_token()
+
+    @patch.object(user, 'g')
+    def test_rate_limit_mocking(self, mock_g):
+        """ test that Redis methods are called at appropriate times """
+        app = flask.Flask(__name__)
+        app.before_request(user.valid_token)
+
+        # test the key is created properly
+        mock_g.redis.sismember.return_value = True
+        mock_g.redis.exists.return_value = False
+        mock_g.cursor.fetchone.return_value = test_record
+        with app.test_request_context('/?token=123'):
+            user.rate_limit()
+        self.assertEqual(
+            ('rate:123', 25, 60**2/user.SPLIT_FACTOR),
+            mock_g.redis.setex.call_args[0]
+        )
+
+        # test if it throws error when rate limited
+        mock_g.redis.sismember.return_value = True
+        mock_g.redis.exists.return_value = True
+        mock_g.redis.get.return_value = 0
+        with app.test_request_context('/?token=123'):
+            with self.assertRaises(errors.AppError):
+                user.rate_limit()
+
+
+class TestUserIntegration(TestingTemplate):
+
+    def test_generate_token(self):
+        """ test that it is supported by the system """
+        user.generate_token()
+
+    def test_rate_limit_via_integration(self):
+        """ test that the rate limiting operates properly """
+        # do N requests to max out token
+        for _ in range(100/user.SPLIT_FACTOR):
+            resp = self.app.get('/housing/rooms?token=integration_test')
+            self.assertEqual(200, resp.status_code)
+
+        resp = self.app.get('/housing/rooms?token=integration_test')
+        self.check_error(resp, 'RATE_LIMIT')
+
+        # delete the token afterwards so test can be run multiple times
+        self.r.delete('rate:integration_test')

--- a/data/tests/test_user.py
+++ b/data/tests/test_user.py
@@ -34,7 +34,8 @@ class TestUser(MockingTemplate):
         # check that the correct query was called
         self.check_query(
             mock_g.cursor.execute,
-            'INSERT INTO users_t (email, token, name) VALUES (%s, %s, %s);',
+            ('INSERT INTO users_t (email, token, name, limit) '
+             'VALUES (%s, %s, %s, %s);'),
             [test_email, test_token, test_user]
         )
         # check that commit() was called
@@ -75,7 +76,8 @@ class TestUser(MockingTemplate):
         self.check_queries(
             mock_g.cursor.execute,
             ['SELECT * FROM users_t WHERE email = %s;',
-             'INSERT INTO users_t (email, token, name) VALUES (%s, %s, %s);'],
+             ('INSERT INTO users_t (email, token, name, limit) '
+              'VALUES (%s, %s, %s, %s);')],
             [[test_email], [test_email, test_token, test_user]]
         )
 

--- a/data/tests/test_user.py
+++ b/data/tests/test_user.py
@@ -34,7 +34,7 @@ class TestUser(MockingTemplate):
         # check that the correct query was called
         self.check_query(
             mock_g.cursor.execute,
-            ('INSERT INTO users_t (email, token, name, limit) '
+            ('INSERT INTO users_t (email, token, name, rate_limit) '
              'VALUES (%s, %s, %s, %s);'),
             [test_email, test_token, test_user]
         )
@@ -76,7 +76,7 @@ class TestUser(MockingTemplate):
         self.check_queries(
             mock_g.cursor.execute,
             ['SELECT * FROM users_t WHERE email = %s;',
-             ('INSERT INTO users_t (email, token, name, limit) '
+             ('INSERT INTO users_t (email, token, name, rate_limit) '
               'VALUES (%s, %s, %s, %s);')],
             [[test_email], [test_email, test_token, test_user]]
         )

--- a/data/tests/test_user.py
+++ b/data/tests/test_user.py
@@ -147,6 +147,3 @@ class TestUserIntegration(TestingTemplate):
 
         resp = self.app.get('/housing/rooms?token=integration_test')
         self.check_error(resp, 'RATE_LIMIT')
-
-        # delete the token afterwards so test can be run multiple times
-        self.r.delete('rate:integration_test')

--- a/dev/dev_dump.sql
+++ b/dev/dev_dump.sql
@@ -3166,7 +3166,7 @@ COPY sections_v2_t (callnumber, sectionfull, course, term, numenrolled, maxsize,
 --
 
 COPY users_t (email, token, name, rate_limit) FROM stdin;
-test@test.com	12345	test	20000
+test@test.com	12345	test	200
 integration_test	integration_test	integration_test	100
 \.
 

--- a/dev/dev_dump.sql
+++ b/dev/dev_dump.sql
@@ -269,7 +269,8 @@ ALTER TABLE public.sections_v2_t OWNER TO postgres;
 CREATE TABLE users_t (
     email character varying(64) NOT NULL,
     token character varying(32) NOT NULL,
-    name character varying(64) NOT NULL
+    name character varying(64) NOT NULL,
+    limit integer
 );
 
 

--- a/dev/dev_dump.sql
+++ b/dev/dev_dump.sql
@@ -270,7 +270,7 @@ CREATE TABLE users_t (
     email character varying(64) NOT NULL,
     token character varying(32) NOT NULL,
     name character varying(64) NOT NULL,
-    limit integer
+    rate_limit integer
 );
 
 
@@ -3165,7 +3165,8 @@ COPY sections_v2_t (callnumber, sectionfull, course, term, numenrolled, maxsize,
 -- Data for Name: users_t; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
-COPY users_t (email, token, name) FROM stdin;
+COPY users_t (email, token, name, rate_limit) FROM stdin;
+test@test.com	12345	test	200
 \.
 
 

--- a/dev/dev_dump.sql
+++ b/dev/dev_dump.sql
@@ -3166,7 +3166,8 @@ COPY sections_v2_t (callnumber, sectionfull, course, term, numenrolled, maxsize,
 --
 
 COPY users_t (email, token, name, rate_limit) FROM stdin;
-test@test.com	12345	test	200
+test@test.com	12345	test	20000
+integration_test	integration_test	integration_test	100
 \.
 
 

--- a/tests.sh
+++ b/tests.sh
@@ -7,6 +7,8 @@ echo '    pep 8 complicance testing'
 echo '--------------------------------------'
 
 flake8 data/auth
+flake8 data/lib/query.py
+flake8 data/lib/converters.py
 flake8 data/errors
 flake8 data/housing
 flake8 data/tests


### PR DESCRIPTION
When a user creates their account they're given a `rate_limit` attribute. This is used to determine their allocation per hour. Currently those accesses are split within the hour by the constant, [split_factor](https://github.com/natebrennand/data.adicu.com/blob/a495316788535c323f72d3168f0706d1d9dd1175/data/auth/user.py#L20). It will be straightforward to change this scheme if we think there's a better way.

Upon making a request, we look for a key in redis, `rate:<TOKEN>`. If it's found, we make sure they still have requests let before decrementing it. If not, we find their allocated rate from postgres and create an expiring key (life: 60 minutes / `split_factor`) with a value = `limit`/`split_factor` before decrementing it and allowing the request.

I wrote a [mocked test](https://github.com/natebrennand/data.adicu.com/blob/a495316788535c323f72d3168f0706d1d9dd1175/data/tests/test_user.py#L110-L132) as well as an [integration test](https://github.com/natebrennand/data.adicu.com/blob/a495316788535c323f72d3168f0706d1d9dd1175/data/tests/test_user.py#L141-L149).

closes #13 & closes #71
This necessitated adding a `rate_limit` column to the `users_t` table in Postgres
