### PR TITLE
update docs & add Redis record

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,14 @@ If anything is wrong, the following commands will help you diagnose the app:
 
 Take a look at the logs, in `/var/log/supervisor` as well.
 
+
 ## Importing Dev Data
 
 We use a partial dump of our data for quick-and-easy development. This gets
 loaded on VM provision by our Vagrant setup scripts. It contains a small subset
 and is not updated frequently, but is sufficient for most feature development
 and bug squashing.
+
 
 ## Data Sources
 
@@ -53,16 +55,20 @@ agreement with the school, but if you have a good reason, we can work something
 out. Otherwise, we prefer that all data access be done through the ADI API; we
 can work with you to provide any features you need in most cases.
 
+
 # app structure
 
-    |-- config/ (config settings and install scripts)
-    |-- Procfile (Heroku instructions on how to run the application)
-    |-- README.md (This file)
-    |-- data/
-        \
-        |-- data.py (the executable for this application)
-        |-- scripts/ (command line helper scripts; database start/stop scripts)
-        |-- static/ (your static files, such as js, css, imgs)
-        |-- tests/ (py.test scripts that should be used during development)
-        |-- templates/ (html templates)
+```
+|-- config/ (config settings and install scripts)
+|-- README.md (This file)
+|-- data/
+    \
+    |-- data.py (the executable for this application)
+    |-- static/ (your static files, such as js, css, imgs)
+    |-- tests/ (unittest scripts that should be used during development)
+    |-- housing/ (files associated with housing endpoints)
+    |-- auth/ (files associated with authentication and rate limiting)
+    |-- lib/ (files used by multiple endpoints for query building)
+```
+
 

--- a/config/bootstrap.sh
+++ b/config/bootstrap.sh
@@ -13,6 +13,8 @@ sudo -u postgres psql -c "CREATE USER adi WITH PASSWORD 'adi'";
 
 # install redis
 sudo apt-get -y install redis-server
+redis-cli -n 1 smembers 12345   # add test token to redis
+redis-cli -n 1 smembers integration_test   # add test token to redis
 
 # install python
 apt-get -y install python

--- a/data/README.md
+++ b/data/README.md
@@ -21,11 +21,21 @@ The endpoints are part of a blueprint in the `housing/housing.py` file.
 ###errors
 
 Contains logic for creating errors.
-Routes are given the catch_error decorator and look for an AppError to be thrown.
+Routes are given the `catch_error` decorator and look for an AppError to be thrown.
 This then returns the defined error.
 
 All errors are defined in `errors/definitions.json`.
 This will be very useful when we start building the documentation.
+
+
+###rate limiting
+
+Defined in `auth/`.
+
+A user is given a set number of API requests per hour.
+These are split between `SPLIT_FACTOR` parts of an hour (i.e., `SPLIT_FACTOR=4`, 15 minute increments).
+
+For testing purposes, use the token `12345`.
 
 
 ###config


### PR DESCRIPTION
updates documentation and adds Redis tokens. The tokens are typically created during the registration phase but it's easier to just insert it on provision than make everyone testing create their own token.
