### PR TITLE
logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - HOST=0.0.0.0
     - DEBUG=TRUE
     - SECRET_KEY=abc123
+    - TESTING=TRUE
 
     - PG_HOST=127.0.0.1
     - PG_PORT=5432

--- a/data/config/flask_config.py
+++ b/data/config/flask_config.py
@@ -16,6 +16,7 @@ try:
     PORT = environ['PORT']
     SECRET_KEY = environ['SECRET_KEY']
     DEBUG = True if environ['DEBUG'] == 'TRUE' else False
+    LOG = environ.get('LOG', 'data.log')
 
     # postgres settings
     PG_USER = environ['PG_USER']

--- a/data/data.py
+++ b/data/data.py
@@ -1,10 +1,13 @@
 
 # library imports
-from flask import Flask, g
+from flask import Flask, g, request
 import psycopg2
 import psycopg2.pool
 import psycopg2.extras
 import redis
+import logging
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
 
 # project libraries
 from errors import errors
@@ -16,6 +19,12 @@ app.config.from_object('config.flask_config')
 # blueprint imports
 from housing.housing import housing as housing_blueprint
 from auth.auth import auth_blueprint
+
+my_logger = logging.getLogger('DataLogger')
+log_format = ('%(asctime)-24s %(client_ip)-10s %(status)s '
+              '%(token)s %(method)s %(uri)s %(resp_time)s'.replace(' ', '\t'))
+handler = RotatingFileHandler(app.config['LOG'], maxBytes=(2 ** 20), backupCount=1)
+handler.setFormatter(logging.Formatter(log_format))
 
 
 pg_pool = psycopg2.pool.SimpleConnectionPool(
@@ -39,10 +48,9 @@ redis_pool = redis.ConnectionPool(
 def get_connections():
     """ Get connections from the Postgres and redis pools. """
     g.pg_conn = pg_pool.getconn()
-    # return python dictionaries from the cursor
     g.cursor = g.pg_conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-
     g.redis = redis.Redis(connection_pool=redis_pool)
+    g.start_time = datetime.now()
 
 
 @app.teardown_request
@@ -50,6 +58,23 @@ def return_connections(*args, **kwargs):
     """ Return the connection to the Postgres connection pool. """
     g.cursor.close()
     pg_pool.putconn(g.pg_conn)
+
+
+@app.after_request
+def log_outcome(resp):
+    """ Outputs to a specified logging file """
+    app.logger.info('', resp.status_code, request.method,
+                    request.path,
+                    extra={
+                        'client_ip': request.remote_addr,
+                        'method': request.method,
+                        'uri': request.path,
+                        'status': resp.status_code,
+                        'resp_time': (datetime.now() -
+                                      g.start_time).microseconds,
+                        'token': '12345'
+                    })
+    return resp
 
 
 # register error handlers
@@ -69,4 +94,5 @@ def home():
         return f.read()
 
 if __name__ == '__main__':
+    app.logger.addHandler(handler)
     app.run(host=app.config['HOST'])

--- a/data/lib/query.py
+++ b/data/lib/query.py
@@ -82,4 +82,6 @@ def build_query(table, config_dict, option=None, page=0):
         limit=PG_LIMIT,
         offset=PG_LIMIT*page
     )
+    if environ['DEBUG'] == 'TRUE':
+        print query, values
     return query, values

--- a/data/lib/query.py
+++ b/data/lib/query.py
@@ -50,7 +50,7 @@ def build_where_statement(config_dict):
             if attr != 'token':
                 raise errors.AppError('INVALID_ATTRIBUTE', attr_name=attr)
     if statements:
-        return 'WHERE '+' AND '.join(statements), values
+        return 'WHERE ' + ' AND '.join(statements), values
     return '', []
 
 
@@ -80,7 +80,7 @@ def build_query(table, config_dict, option=None, page=0):
         from_stmnt=build_from_statement(table),
         where_stmnt=where_statement,
         limit=PG_LIMIT,
-        offset=PG_LIMIT*page
+        offset=PG_LIMIT * page
     )
     if environ['DEBUG'] == 'TRUE':
         print query, values

--- a/data/lib/query.py
+++ b/data/lib/query.py
@@ -82,6 +82,6 @@ def build_query(table, config_dict, option=None, page=0):
         limit=PG_LIMIT,
         offset=PG_LIMIT * page
     )
-    if environ['DEBUG'] == 'TRUE':
+    if environ.get('DEBUG_SQL', 'FALSE') == 'TRUE':
         print query, values
     return query, values

--- a/tests.sh
+++ b/tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source /vagrant/config/settings.dev
+export TESTING=TRUE
 
 echo '--------------------------------------'
 echo '    pep 8 complicance testing'


### PR DESCRIPTION
Uses [RotatingFileHandler](https://docs.python.org/2/library/logging.handlers.html#rotatingfilehandler) so it will automatically start new files every mB.

Defaults to logging at `data.log`, but can be set with the `LOG` environment variable.

Logs currently look like:

```
datetime                    referrer    status   token        method  URI           time (microseconds)
----------------------------------------------------------------------------------------------------------
2014-04-06 04:25:35,438     None        200 integration_test    GET /housing/rooms  19155
2014-04-06 04:25:35,459     None        200 integration_test    GET /housing/rooms  17959
2014-04-06 04:25:35,486     None        200 integration_test    GET /housing/rooms  21324
2014-04-06 04:25:35,510     None        200 integration_test    GET /housing/rooms  18486
2014-04-06 04:25:35,532     None        200 integration_test    GET /housing/rooms  18472
2014-04-06 04:25:35,557     None        200 integration_test    GET /housing/rooms  21113
2014-04-06 04:25:35,564     None        429 integration_test    GET /housing/rooms  982
2014-04-06 04:25:51,454     None        400 12345   GET /housing/buildings/options/fake_attr    2479
2014-04-06 04:25:51,459     None        400 12345   GET /housing/buildings/options/another_fake_attr    559
2014-04-06 04:25:51,464     None        200 12345   GET /housing/buildings/options/building 1644
2014-04-06 04:25:51,469     None        401 NO_TOKEN    GET /housing/buildings/options/building 208
2014-04-06 04:25:51,473     None        401 false   GET /housing/buildings/options/building 337
2014-04-06 04:25:51,477     None        200 12345   GET /housing/buildings/options/lounge   1204
2014-04-06 04:25:51,483     None        200 12345   GET /housing/buildings/options/building 1588
2014-04-06 04:25:51,489     None        400 12345   GET /housing/buildings/5    1594
2014-04-06 04:25:51,497     None        400 12345   GET /housing/rooms/100  3952
2014-04-06 04:25:51,504     None        200 12345   GET /housing/buildings  2390
2014-04-06 04:25:51,510     None        400 12345   GET /housing/rooms/options/fake_attr    609
2014-04-06 04:25:51,513     None        400 12345   GET /housing/rooms/options/another_fake_attr    686
2014-04-06 04:25:51,520     None        200 12345   GET /housing/rooms/options/room_type    2028
2014-04-06 04:25:51,524     None        401 NO_TOKEN    GET /housing/rooms/options/room_type    200
2014-04-06 04:25:51,528     None        401 false   GET /housing/rooms/options/room_type    337
2014-04-06 04:25:51,533     None        200 12345   GET /housing/rooms/options/room_type    1600
2014-04-06 04:25:51,538     None        200 12345   GET /housing/rooms/options/room_type    1416
2014-04-06 04:25:51,545     None        400 12345   GET /housing/rooms/5    1822
2014-04-06 04:25:51,552     None        400 12345   GET /housing/rooms/100  2735
2014-04-06 04:25:51,565     None        200 12345   GET /housing/rooms  8635
2014-04-06 04:25:51,690     None        200 integration_test    GET /housing/rooms  20084
2014-04-06 04:25:51,713     None        200 integration_test    GET /housing/rooms  19306
2014-04-06 04:25:51,735     None        200 integration_test    GET /housing/rooms  17436
2014-04-06 04:25:51,757     None        200 integration_test    GET /housing/rooms  18389
2014-04-06 04:25:51,779     None        200 integration_test    GET /housing/rooms  17609
```

closes #94

Also suppressed logs during tests because the default output crowded the test results.
